### PR TITLE
Switch to checking ActiveRecord version directly (instead of Rails)

### DIFF
--- a/lib/where-or.rb
+++ b/lib/where-or.rb
@@ -1,6 +1,6 @@
-abort "Congrats for being on Rails 5. Now please remove this patch" if Rails::VERSION::MAJOR > 4
+abort "Congrats for being on Rails 5. Now please remove this patch" if ActiveRecord::VERSION::MAJOR > 4
 # Tested on Rails Rails 4.2.3
-warn "Patching ActiveRecord::Relation#or.  This might blow up" if Rails.version < '4.2.3'
+warn "Patching ActiveRecord::Relation#or.  This might blow up" if ActiveRecord.version.to_s < '4.2.3'
 # https://github.com/rails/rails/commit/9e42cf019f2417473e7dcbfcb885709fa2709f89.patch
 # CHANGELOG.md
 # *   Added the `#or` method on ActiveRecord::Relation, allowing use of the OR


### PR DESCRIPTION
We use ActiveRecord but not Rails. This should have the same effect as before but without the hard dependency on Rails proper - AR versioning should be identical to Rails versioning.
