### PR TITLE
Attempt to fix errors like this:

### DIFF
--- a/lib/where-or.rb
+++ b/lib/where-or.rb
@@ -127,6 +127,15 @@ ActiveSupport.on_load(:active_record) do
       )
     end
 
+    # monkey patching around the fact that the rails 4.2 implementation is an array of things, all 'and'd together
+    # but the rails 5 implemention that they backported replaces that array with ActiveRecord::Relation::WhereClause that
+    # contains AND's and OR's ... on testing, I discover it mostly works except when you attempt to use the preloader,
+    # which this hack here fixes.
+    def -(other)
+      raise "where-or internal error: expect only empty array, not #{other.inspect}" unless other.empty? || (other.size == 1 && other.first.blank?)
+      [self]
+    end
+
     def merge(other)
       ActiveRecord::Relation::WhereClause.new(
         predicates_unreferenced_by(other) + other.predicates,


### PR DESCRIPTION
NoMethodError:
       undefined method `-' for #<ActiveRecord::Relation::WhereClause:0x007f5c0fd48e48>
     # /mnt/home/u1858/bundle/ruby/2.3.0/gems/activerecord-4.2.6/lib/active_record/relation/query_methods.rb:868:in `build_arel'

when you use the preloader, like this:

ActiveRecord::Associations::Preloader.new.preload(Suggestions::Library.last, [:library_meals, {:available_meals => [:available_meal_times, :servings => [:measurement, {:food => :measurements}]]}])