### PR TITLE
Use version comparison instead of sting comparison

### DIFF
--- a/lib/where-or.rb
+++ b/lib/where-or.rb
@@ -1,6 +1,6 @@
 abort "Congrats for being on Rails 5. Now please remove this patch by getting rid of the `where-or` gem" if ActiveRecord::VERSION::MAJOR > 4
 # Tested on Rails Rails 4.2.3
-warn "Patching ActiveRecord::Relation#or.  This might blow up" if ActiveRecord.version.to_s < '4.2.3'
+warn "Patching ActiveRecord::Relation#or.  This might blow up" if ActiveRecord.version < Gem::Version.new('4.2.3')
 # https://github.com/rails/rails/commit/9e42cf019f2417473e7dcbfcb885709fa2709f89.patch
 # CHANGELOG.md
 # *   Added the `#or` method on ActiveRecord::Relation, allowing use of the OR


### PR DESCRIPTION
```
[4] pry(main)> ActiveRecord.version.to_s
=> "4.2.10"
[5] pry(main)> ActiveRecord.version.to_s < '4.2.3'
=> true
[6] pry(main)> ActiveRecord.version < Gem::Version.new('4.2.3')
=> false
```

Comparing string version fails for rails 4.2.10